### PR TITLE
feat: Added javadoc plugin #17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,18 @@
 	  <artifactId>jetty-server</artifactId>
 	  <version>7.0.2.v20100331</version>
 	</dependency>
-    
   </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.4.1</version>
+        <configuration>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  
 </project>


### PR DESCRIPTION
Java documentation files can now be generated with: `mvn javadoc:javadoc`

For more information, see: [https://maven.apache.org/plugins/maven-javadoc-plugin/](https://maven.apache.org/plugins/maven-javadoc-plugin/)

Closes #17 