### PR TITLE
fix: fixed errors and warnings from javadoc generation #55

### DIFF
--- a/src/main/java/org/group26/HelperFucntion.java
+++ b/src/main/java/org/group26/HelperFucntion.java
@@ -6,14 +6,24 @@ import java.io.IOException;
 
 import org.json.JSONObject;
 
+/**
+ * 	General functions to help server.
+ * 
+ * 	@author andersblomqvist
+ * 	@author a-kbd
+ * 	@author coffecup25
+ * 	@author darpos
+ * 	@author tjex
+ */
 public class HelperFucntion {
 
 	/**
 	 *	Reads the connection response and returns it as an JSON object.
 	 * 
-	 * 	@param reader
+	 * 	@param reader Buffered reader from response object.
 	 * 	@return JSONObject with response from connection.
-	 * 	@throws IOException
+	 * 
+	 * 	@throws IOException If an I/O error occurs.
 	 */
 	public static JSONObject getJsonFromRequestReader(BufferedReader reader) throws IOException {
 		String inputline;


### PR DESCRIPTION
- Added appropriate comments and reformatted some to follow javadoc comment syntax.

Running `mvn javadoc:javadoc` succeeds but will still give x2 warnings. However, these warnings are not important.

Closes #55 