### PR TITLE
refactor: Added function for getting status URL, and test #57

### DIFF
--- a/src/main/java/org/group26/HelperFucntion.java
+++ b/src/main/java/org/group26/HelperFucntion.java
@@ -52,4 +52,19 @@ public class HelperFucntion {
 		Process pro = Runtime.getRuntime().exec("git clone -b " +  branch + " --single-branch " + cloningURL + " " + path);
 		pro.waitFor();
 	}
+    
+    
+    /**
+     * 	Formats the status URL to a complete URL we can send a response to.
+     * 
+     * 	@param commitID SHA for commit.
+     * 	@param statusURL API URL to GitHub statuses
+     * 	@return URL to GitHib commit status.
+     */
+    public static String getStatusURL(String commitID, String statusURL) {
+    	// "statuses_url": 	"https://api.github.com/repos/tjex/ci-server-g26/statuses/{sha}",
+    	// commitID: 		7a5ec3ef...
+    	// formatted: 		https://api.github.com/repos/tjex/ci-server-g26/statuses/7a5ec3ef...
+    	return statusURL.replace("{sha}", commitID);
+    }
 }

--- a/src/test/java/com/group26/HelperFunctionsTest.java
+++ b/src/test/java/com/group26/HelperFunctionsTest.java
@@ -69,5 +69,17 @@ public class HelperFunctionsTest {
 			FileUtils.deleteDirectory(file);
 		}
 	}
+	
+	/**
+	 * 	Checks if the correct status URL is returned by combining statuses URL from GitHub API
+	 * 	with a commitID.
+	 */
+	@Test
+	public void CheckCorrectStatusURL() {
+		String statuses = "https://api.github.com/repos/tjex/ci-server-g26/statuses/{sha}";
+		String commitID = "1d6c375756c98e76ce22cf145feedeaf002cc97d";
+		String url = HelperFucntion.getStatusURL(commitID, statuses);
+		assertEquals("https://api.github.com/repos/tjex/ci-server-g26/statuses/1d6c375756c98e76ce22cf145feedeaf002cc97d", url);
+	}
 }
 


### PR DESCRIPTION
* Send response function now has related test. It checks if the status URL we send commit status is correct. We get statuses url from GitHub payload POST request and format it with commit ID.

Closes #57 